### PR TITLE
Add a tighter type for `content`, `group`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ By default, the following is used:
 
 If `behavior` is `wrap`, then `content` is ignored.
 
-If `content` is a function, it’s called with the current heading (`Node`) and
+If `content` is a function, it’s called with the current heading (`Element`) and
 should return one or more nodes:
 
 ```js
@@ -131,7 +131,7 @@ There is no default.
 
 If `behavior` is `prepend`, `append`, or `wrap`, then `group` is ignored.
 
-If `group` is a function, it’s called with the current heading (`Node`) and
+If `group` is a function, it’s called with the current heading (`Element`) and
 should return a hast node.
 
 ```js

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 // Minimum TypeScript Version: 3.5
 import {Plugin} from 'unified'
-import {Node, Properties} from 'hast'
+import {Element, Node, Properties} from 'hast'
 
 /**
  * Automatically add links to headings.
@@ -28,13 +28,13 @@ declare namespace autolinkHeadings {
      *
      * @default { type: 'element', tagName: 'span', properties: {className: ['icon', 'icon-link']}, children: [] }
      */
-    content?: Node | ((heading: Node) => Node[])
+    content?: Node | ((heading: Element) => Node[])
 
     /**
      * `hast` node to wrap the heading and link with, if `behavior` is
      * `'before'` or `'after'`. There is no default.
      */
-    group?: Node | ((heading: Node) => Node)
+    group?: Node | ((heading: Element) => Node)
   }
 }
 


### PR DESCRIPTION
minor adjustment of the `content` and `group` function arg type: they receive a heading `Element` (checked [here](https://github.com/rehypejs/rehype-autolink-headings/blob/104cc77b981dba54a126cc46db901c306b3c4569/index.js#L42)). changed this so typescript won't complain when accessing the heading's `properties`.