### PR TITLE
feat: add linkPrefix option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,8 @@
  *   How to create links.
  * @property {Behavior} [behaviour]
  *   Please use `behavior` instead
+ * @property {string} [linkPrefix='']
+ *   Prefix for the generated link
  * @property {Properties} [properties]
  *   Extra properties to set on the link when injecting.
  *   Defaults to `{ariaHidden: true, tabIndex: -1}` when `'prepend'` or
@@ -59,6 +61,7 @@ export default function rehypeAutolinkHeadings(options = {}) {
   const behavior = options.behaviour || options.behavior || 'prepend'
   const content = options.content || contentDefaults
   const group = options.group
+  const prefix = options.linkPrefix || ''
   const is = convertElement(options.test)
 
   /** @type {import('unist-util-visit/complex-types').Visitor<Element>} */
@@ -91,7 +94,7 @@ export default function rehypeAutolinkHeadings(options = {}) {
   /** @type {import('unist-util-visit/complex-types').Visitor<Element>} */
   function inject(node) {
     node.children[behavior === 'prepend' ? 'unshift' : 'push'](
-      create(node, extend(true, {}, props), toChildren(content, node))
+      create(node, extend(true, {}, props), toChildren(content, node), prefix)
     )
 
     return [SKIP]
@@ -106,7 +109,8 @@ export default function rehypeAutolinkHeadings(options = {}) {
     const link = create(
       node,
       extend(true, {}, props),
-      toChildren(content, node)
+      toChildren(content, node),
+      prefix
     )
     let nodes = behavior === 'before' ? [link, node] : [node, link]
 
@@ -126,7 +130,9 @@ export default function rehypeAutolinkHeadings(options = {}) {
 
   /** @type {import('unist-util-visit/complex-types').Visitor<Element>} */
   function wrap(node) {
-    node.children = [create(node, extend(true, {}, props), node.children)]
+    node.children = [
+      create(node, extend(true, {}, props), node.children, prefix)
+    ]
     return [SKIP]
   }
 
@@ -154,16 +160,17 @@ export default function rehypeAutolinkHeadings(options = {}) {
    * @param {Element} node
    * @param {Properties} props
    * @param {ElementChild[]} children
+   * @param {string} prefix
    * @returns {Element}
    */
-  function create(node, props, children) {
+  function create(node, props, children, prefix) {
     return {
       type: 'element',
       tagName: 'a',
       properties: Object.assign({}, props, {
         // Fix hast types and make them required.
         /* c8 ignore next */
-        href: '#' + (node.properties || {}).id
+        href: prefix + '#' + (node.properties || {}).id
       }),
       children
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-autolink-headings",
-  "version": "6.2.1",
+  "version": "6.2.0",
   "description": "rehype plugin to add links to headings",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rehype-autolink-headings",
-  "version": "6.1.1",
+  "version": "6.2.1",
   "description": "rehype plugin to add links to headings",
   "license": "MIT",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -188,9 +188,11 @@ should return a hast node.
 
 ###### `options.linkPrefix`
 
-String to add as a prefix to the generated link. Defaults to ''.
+String to add as a prefix to the generated link. Defaults to `''`.
 
-This can be used if you want to convert your relative anchor links (`#my-anchor`) into absolute anchor links (`/some/path#my-anchor`), e.g. when you're using a `<base>` tag on your site.
+This can be used if you want to convert your relative anchor links (`#my-anchor`)
+into absolute anchor links (`/some/path#my-anchor`), e.g. when you’re using a
+`<base>` tag on your site.
 
 
 ###### `options.test`

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ should return a hast node.
 
 ###### `options.linkPrefix`
 
-String to add as a prefix to the generated link. Defaults to `''`.
+String to add as a prefix to the generated link.  Defaults to `''`.
 
 This can be used if you want to convert your relative anchor links (`#my-anchor`)
 into absolute anchor links (`/some/path#my-anchor`), e.g. when you’re using a

--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,6 @@ This can be used if you want to convert your relative anchor links (`#my-anchor`
 into absolute anchor links (`/some/path#my-anchor`), e.g. when you’re using a
 `<base>` tag on your site.
 
-
 ###### `options.test`
 
 Test to define which heading elements are linked.

--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,13 @@ should return a hast node.
 > 👉 **Note**: this option is ignored when the behavior is `prepend`, `append`,
 > or `wrap`
 
+###### `options.linkPrefix`
+
+String to add as a prefix to the generated link. Defaults to ''.
+
+This can be used if you want to convert your relative anchor links (`#my-anchor`) into absolute anchor links (`/some/path#my-anchor`), e.g. when you're using a `<base>` tag on your site.
+
+
 ###### `options.test`
 
 Test to define which heading elements are linked.

--- a/test/fixtures/link-prefix/config.json
+++ b/test/fixtures/link-prefix/config.json
@@ -1,0 +1,3 @@
+{
+  "linkPrefix": "my-prefix"
+}

--- a/test/fixtures/link-prefix/input.html
+++ b/test/fixtures/link-prefix/input.html
@@ -1,0 +1,1 @@
+<h1 id="bravo">Charlie</h1>

--- a/test/fixtures/link-prefix/output.html
+++ b/test/fixtures/link-prefix/output.html
@@ -1,0 +1,1 @@
+<h1 id="bravo"><a aria-hidden="true" tabindex="-1" href="my-prefix#bravo"><span class="icon icon-link"></span></a>Charlie</h1>


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

I've added a `linkPrefix` option which adds a static prefix to every generated link. One possible use case for this is to convert relative anchor links (`#my-anchor`) to absolute anchor links (`https://mypage.com/content/blogpost#myanchor`).

This feature/wish has been mentioned before in this discussion: https://github.com/rehypejs/rehype/discussions/104

<!--do not edit: pr-->
